### PR TITLE
Update music_transcription_with_transformers.ipynb

### DIFF
--- a/mt3/colab/music_transcription_with_transformers.ipynb
+++ b/mt3/colab/music_transcription_with_transformers.ipynb
@@ -68,6 +68,7 @@
         "!pip install pyfluidsynth\n",
         "# pin CLU for python 3.7 compatibility\n",
         "!pip install clu==0.0.7\n",
+        "!pip install folium==0.2.1\n",
         "# pin Orbax to use Checkpointer\n",
         "!pip install orbax==0.0.2\n",
         "\n",


### PR DESCRIPTION
fix an error when use MT3 in colab
![image](https://user-images.githubusercontent.com/45501959/180651242-4c7a8a37-fd58-4fb3-b44d-ed7841908a81.png)

ERROR: pip’s dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
datascience 0.10.6 requires folium==0.2.1, but you have folium 0.8.3 which is incompatible.