### PR TITLE
Bugfix in event decoder (?)

### DIFF
--- a/mt3/run_length_encoding.py
+++ b/mt3/run_length_encoding.py
@@ -305,7 +305,7 @@ def decode_events(
       continue
     if event.type == 'shift':
       cur_steps += event.value
-      cur_time = start_time + cur_steps / codec.steps_per_second
+      cur_time = state.current_time + cur_steps / codec.steps_per_second
       if max_time and cur_time > max_time:
         dropped_events = len(tokens) - token_idx
         break


### PR DESCRIPTION
# Background

While running this decoder on a sequence of tokens (midifile -> `NoteSequence` -> event_tokens), I realised that after every note is processed and we return to processing shifts, the `cur_time` is reset (since `start_time` is 0). This then causes an exception to be thrown from `note_sequences#decode_note_event`:

```py
if time < state.current_time:
    raise ValueError('event time < current time, %f < %f' % (
        time, state.current_time))
```

I believe the `cur_time` should be an offset of `state.current_time`, not of `start_time` - this allows the decoding sequence to pick up where it left off along the timeline.