### PR TITLE
fix module 'jax' has no attribute 'tree_multimap'

### DIFF
--- a/mt3/colab/music_transcription_with_transformers.ipynb
+++ b/mt3/colab/music_transcription_with_transformers.ipynb
@@ -70,6 +70,8 @@
         "!pip install clu==0.0.7\n",
         "# pin Orbax to use Checkpointer\n",
         "!pip install orbax==0.0.2\n",
+        "#Install the correct version of the jax package\n",
+        "!pip install jax==0.3.15\n",
         "\n",
         "# install t5x\n",
         "!git clone --branch=main https://github.com/google-research/t5x\n",


### PR DESCRIPTION
Set the jax package to the correct version.
Fixed issue with #71 